### PR TITLE
Define rate limiting of mDNS messages

### DIFF
--- a/draft-ietf-rtcweb-mdns-ice-candidates.md
+++ b/draft-ietf-rtcweb-mdns-ice-candidates.md
@@ -648,10 +648,10 @@ A malicious Web application could flood the local network with mDNS messages by:
 limiting rule, in which a given question or record on a given interface cannot be
 sent less than one second since its last transmission. This rate limiting rule
 however does not mitigate the above attacks, in which new names, hence new
-questions or records, are constantly created and sent. A browser-wide mDNS
-message rate limit MUST be provided for both mDNS queries and responses that can
-be dispatched during the ICE candidate gathering and processing described in
-{{principle}}. A browser MAY implement more specific rate limits, e.g. to
+questions or records, are constantly created and sent. Therefore, a browser-wide
+mDNS message rate limit MUST be provided for all mDNS queries and responses that
+are dispatched during the ICE candidate gathering and processing described in
+{{principle}}. A browser MAY implement more specific rate limits, e.g., to
 ensure a single origin does not prevent other origins from registering,
 unregistering, or resolving mDNS names.
 

--- a/draft-ietf-rtcweb-mdns-ice-candidates.md
+++ b/draft-ietf-rtcweb-mdns-ice-candidates.md
@@ -651,27 +651,9 @@ attacks, in which new names, hence new records, are constantly created and sent.
 A browser-wide mDNS message rate limit MUST be provided for all messages
 that can be indirectly dispatched by a web application, namely the probing
 queries, announcement responses, resolution queries, and goodbye responses
-associated with mDNS. In addition to the multicast rate limiting defined in
-{{RFC6762}}, for all mDNS queries including the probing queries, the interval
-between any two queries SHOULD be at least one second. For mDNS responses, we
-recommend the following rate limiting scheme that applies different restrictions
-based on the mDNS message type.
-
-1. Per-response rate limiting. Announcement ({{RFC6762}}, Section 8.3) and
-   goodbye ({{RFC6762}}, Section 10.1) responses SHOULD be limited per-response
-   on each interface so that the time elapsed between any two transmissions of
-   mDNS responses containing the above messages is no less than one second on
-   the given interface.
-
-2. Per-record rate limiting. Responses containing resource records for name
-   resolution, as well as negative responses to non-probing queries for non-existing
-   records of generated mDNS names, SHOULD be rate limited per record. The time elapsed
-   of any contained record must be no less than one second from the last time
-   that a per-record rate-limited response that also contains this record is
-   transmitted.
-
-3. No rate limiting. Responses to probing queries, including negative responses,
-   SHOULD be sent without delay ({{RFC6762}}, Section 6).
+associated with mDNS. Such a rate limiting rule SHOULD NOT allow responses from
+an origin to queries for the ICE candidate processing blocked by mDNS messages
+from a different origin.
 
 Malicious Responses to Deny Name Registration
 ---------------------------------------------

--- a/draft-ietf-rtcweb-mdns-ice-candidates.md
+++ b/draft-ietf-rtcweb-mdns-ice-candidates.md
@@ -651,7 +651,27 @@ attacks, in which new names, hence new records, are constantly created and sent.
 A browser-wide mDNS message rate limit MUST be provided for all messages
 that can be indirectly dispatched by a web application, namely the probing
 queries, announcement responses, resolution queries, and goodbye responses
-associated with mDNS.
+associated with mDNS. In addition to the multicast rate limiting defined in
+{{RFC6762}}, for all mDNS queries including the probing queries, the interval
+between any two queries SHOULD be at least one second. For mDNS responses, we
+recommend the following rate limiting scheme that applies different restrictions
+based on the mDNS message type.
+
+1. Per-response rate limiting. Announcement ({{RFC6762}}, Section 8.3) and
+   goodbye ({{RFC6762}}, Section 10.1) responses SHOULD be limited per response
+   on each interface so that the time elapsed between any two transmissions of
+   mDNS responses containing the above messages is no less than one second on
+   the given interface.
+
+2. Per-record rate limiting. Responses containing resource records for name
+   resolution, and also negative responses to non-probing queries for non-existing
+   records of generated mDNS names, SHOULD be rate limited per record. The time elapsed
+   of any contained record must be no less than one second from the last time
+   that a per-record rate-limited response that also contains this record is
+   transmitted.
+
+3. No rate limiting. Response, including negative responses, to probing queries
+   SHOULD be sent without delay ({{RFC6762}}, Section 6).
 
 Malicious Responses to Deny Name Registration
 ---------------------------------------------

--- a/draft-ietf-rtcweb-mdns-ice-candidates.md
+++ b/draft-ietf-rtcweb-mdns-ice-candidates.md
@@ -644,16 +644,16 @@ A malicious Web application could flood the local network with mDNS messages by:
 - adding fictitious remote ICE host candidates with mDNS names.
 
 
-{{RFC6762}} defines a per-record multicast rate limiting rule, in which a given
-record on a given interface cannot be sent less than one second since its last
-transmission. This rate limiting rule however does not mitigate the above
-attacks, in which new names, hence new records, are constantly created and sent.
-A browser-wide mDNS message rate limit MUST be provided for all unsolicited
-messages that can be dispatched by a web application, namely the probing
-queries, announcement responses, and goodbye responses associated with mDNS.
-Such a rate limiting rule SHOULD also ensure that mDNS messages sent by
-a page do not block mDNS messages for name resolution in the ICE candidate
-processing of another page, especially if these pages have different origins.
+{{RFC6762}} defines a general per-question and per-record multicast rate
+limiting rule, in which a given question or record on a given interface cannot be
+sent less than one second since its last transmission. This rate limiting rule
+however does not mitigate the above attacks, in which new names, hence new
+questions or records, are constantly created and sent. A browser-wide mDNS
+message rate limit MUST be provided for both mDNS queries and responses that can
+be dispatched during the ICE candidate gathering and processing described in
+{{principle}}. A browser MAY implement more specific rate limits, e.g. to
+ensure a single origin does not prevent other origins from registering,
+unregistering, or resolving mDNS names.
 
 Malicious Responses to Deny Name Registration
 ---------------------------------------------

--- a/draft-ietf-rtcweb-mdns-ice-candidates.md
+++ b/draft-ietf-rtcweb-mdns-ice-candidates.md
@@ -648,12 +648,12 @@ A malicious Web application could flood the local network with mDNS messages by:
 record on a given interface cannot be sent less than one second since its last
 transmission. This rate limiting rule however does not mitigate the above
 attacks, in which new names, hence new records, are constantly created and sent.
-A browser-wide mDNS message rate limit MUST be provided for all messages
-that can be indirectly dispatched by a web application, namely the probing
-queries, announcement responses, resolution queries, and goodbye responses
-associated with mDNS. Such a rate limiting rule SHOULD NOT allow responses from
-an origin to queries for the ICE candidate processing blocked by mDNS messages
-from a different origin.
+A browser-wide mDNS message rate limit MUST be provided for all unsolicited
+messages that can be dispatched by a web application, namely the probing
+queries, announcement responses, and goodbye responses associated with mDNS.
+Such a rate limiting rule SHOULD also ensure that mDNS messages sent by
+a page do not block mDNS messages for name resolution in the ICE candidate
+processing of another page, especially if these pages have different origins.
 
 Malicious Responses to Deny Name Registration
 ---------------------------------------------

--- a/draft-ietf-rtcweb-mdns-ice-candidates.md
+++ b/draft-ietf-rtcweb-mdns-ice-candidates.md
@@ -658,19 +658,19 @@ recommend the following rate limiting scheme that applies different restrictions
 based on the mDNS message type.
 
 1. Per-response rate limiting. Announcement ({{RFC6762}}, Section 8.3) and
-   goodbye ({{RFC6762}}, Section 10.1) responses SHOULD be limited per response
+   goodbye ({{RFC6762}}, Section 10.1) responses SHOULD be limited per-response
    on each interface so that the time elapsed between any two transmissions of
    mDNS responses containing the above messages is no less than one second on
    the given interface.
 
 2. Per-record rate limiting. Responses containing resource records for name
-   resolution, and also negative responses to non-probing queries for non-existing
+   resolution, as well as negative responses to non-probing queries for non-existing
    records of generated mDNS names, SHOULD be rate limited per record. The time elapsed
    of any contained record must be no less than one second from the last time
    that a per-record rate-limited response that also contains this record is
    transmitted.
 
-3. No rate limiting. Response, including negative responses, to probing queries
+3. No rate limiting. Responses to probing queries, including negative responses,
    SHOULD be sent without delay ({{RFC6762}}, Section 6).
 
 Malicious Responses to Deny Name Registration


### PR DESCRIPTION
PR of #86 

This PR aims to address the rate limiting not only for the queries but also the responses.